### PR TITLE
#10 render results on page load with query

### DIFF
--- a/templates/partials/tntsearch.html.twig
+++ b/templates/partials/tntsearch.html.twig
@@ -4,7 +4,7 @@
 <form role="form">
     {% block tntsearch_input %}
     <div id="tntsearch-wrapper" class="form-group">
-        <input type="text" class="form-control tntsearch-field" data-tntsearch="{{ options|json_encode|e('html_attr') }}" placeholder="{{ placeholder }}" value={{ query }}>
+        <input type="text" class="form-control tntsearch-field" data-tntsearch="{{ options|json_encode|e('html_attr') }}" placeholder="{{ placeholder }}" value="{{ query }}">
     </div>
     {% endblock %}
     <div class="tntsearch-results{{ in_page ? ' tntsearch-inpage' : '' }}">

--- a/templates/partials/tntsearch.html.twig
+++ b/templates/partials/tntsearch.html.twig
@@ -4,10 +4,14 @@
 <form role="form">
     {% block tntsearch_input %}
     <div id="tntsearch-wrapper" class="form-group">
-        <input type="text" class="form-control tntsearch-field" data-tntsearch="{{ options|json_encode|e('html_attr') }}" placeholder="{{ placeholder }}">
+        <input type="text" class="form-control tntsearch-field" data-tntsearch="{{ options|json_encode|e('html_attr') }}" placeholder="{{ placeholder }}" value={{ query }}>
     </div>
     {% endblock %}
-    <div class="tntsearch-results{{ in_page ? ' tntsearch-inpage' : '' }}"></div>
+    <div class="tntsearch-results{{ in_page ? ' tntsearch-inpage' : '' }}">
+    {% if tntsearch_results is defined and tntsearch_results is not empty %}
+        {% include 'tntquery-ajax.html.twig' %}
+    {% endif %}
+    </div>
 
     <p class="tntsearch-powered-by">
         Powered by <a href="https://github.com/trilbymedia/grav-plugin-tntsearch" target="_blank">TNTSearch</a>


### PR DESCRIPTION
Addresses issue #10 

- Adds the `query` as the default value in the input box. If `query` is undefined, the value will be nothing and the placeholder will still be shown.
- If `tntsearch_results` is defined (i.e. the search ran already: `/search?q=findthis`), then the page will render the `tntquery-ajax` template on load, showing results in the exact same fashion as the ajax search would.