### PR TITLE
Update tntsearch.js

### DIFF
--- a/assets/admin/tntsearch.js
+++ b/assets/admin/tntsearch.js
@@ -35,7 +35,7 @@
 
             $.ajax({
                 type: 'POST',
-                url: GravAdmin.config.base_url_relative + '.json/task:reindexTNTSearch',
+                url: GravAdmin.config.base_url_relative + '.json/task' + GravAdmin.config.param_sep + 'reindexTNTSearch'
                 data: { 'admin-nonce': GravAdmin.config.admin_nonce }
             }).done(function(done) {
                 if (done.status === 'success') {


### PR DESCRIPTION
Fix for windows. Param separator should come from config - not hardcoded.