### PR TITLE
Search with JavaScript disabled

### DIFF
--- a/templates/partials/tntsearch.html.twig
+++ b/templates/partials/tntsearch.html.twig
@@ -8,10 +8,10 @@
 
 {% set options = { uri: url, limit: limit, snippet: snippet, min: min, in_page: in_page, live_update: live_update, search_type: search_type } %}
 
-<form role="form" class="tntsearch-form">
+<form role="form" class="tntsearch-form" action="" method="get">
     {% block tntsearch_input %}
     <div id="tntsearch-wrapper" class="form-group{{ dropdown ? ' tntsearch-dropdown' : '' }}">
-        <input type="text" class="form-control form-input tntsearch-field{{ in_page ? ' tntsearch-field-inpage' : '' }}" data-tntsearch="{{ options|json_encode|e('html_attr') }}" placeholder="{{ placeholder }}" value="{{ not dropdown ? query|e : '' }}" autofocus>
+        <input type="text" name="q" class="form-control form-input tntsearch-field{{ in_page ? ' tntsearch-field-inpage' : '' }}" data-tntsearch="{{ options|json_encode|e('html_attr') }}" placeholder="{{ placeholder }}" value="{{ not dropdown ? query|e : '' }}" autofocus>
         <span class="tntsearch-clear"{{ not query or dropdown ? ' style="display: none;"' : '' }}>&times;</span>
     </div>
     {% endblock %}

--- a/templates/partials/tntsearch.html.twig
+++ b/templates/partials/tntsearch.html.twig
@@ -5,10 +5,11 @@
 {% set search_type = search_type|default(config.get('plugins.tntsearch.search_type', 'auto')) %}
 {% set placeholder = placeholder|default('Search...') %}
 {% set live_update = in_page ? live_update|default(config.get('plugins.tntsearch.live_uri_update', 1)) : 0 %}
+{% set nojs_action = config.get('plugins.tntsearch.search_route', '/search')|trim('/') %}
 
 {% set options = { uri: url, limit: limit, snippet: snippet, min: min, in_page: in_page, live_update: live_update, search_type: search_type } %}
 
-<form role="form" class="tntsearch-form" action="" method="get">
+<form role="form" class="tntsearch-form" action="{{ nojs_action }}" method="get">
     {% block tntsearch_input %}
     <div id="tntsearch-wrapper" class="form-group{{ dropdown ? ' tntsearch-dropdown' : '' }}">
         <input type="text" name="q" class="form-control form-input tntsearch-field{{ in_page ? ' tntsearch-field-inpage' : '' }}" data-tntsearch="{{ options|json_encode|e('html_attr') }}" placeholder="{{ placeholder }}" value="{{ not dropdown ? query|e : '' }}" autofocus>


### PR DESCRIPTION
Hi there,

thanks for this amazing plugin. I noticed that it doesn't work with javascript disabled (tested on https://learn.getgrav.org/16/search and my own site). So I tried some stuff and this is what worked for me. It loads the result page on hitting Enter - instead of reloading the search page.

As the [default submit is deactivated](https://github.com/trilbymedia/grav-plugin-tntsearch/blob/35859bb8c4955383bc232bf789a575b53450668f/app/main.js#L25) if javascript is active, this shouldn't have a side effect. If it has nevertheless or could be done better, please let me know.