### PR TITLE
Fix running scheduled search index job.

### DIFF
--- a/tntsearch.php
+++ b/tntsearch.php
@@ -110,7 +110,7 @@ class TNTSearchPlugin extends Plugin
             $scheduler = $e['scheduler'];
             $at = $this->config->get('plugins.tntsearch.scheduled_index.at');
             $logs = $this->config->get('plugins.tntsearch.scheduled_index.logs');
-            $job = $scheduler->addCommand('bin/plugin tntsearch index', [], 'tntsearch-index');
+            $job = $scheduler->addCommand('bin/plugin', ['tntsearch', 'index'], 'tntsearch-index');
             $job->at($at);
             $job->output($logs);
             $job->backlink('/plugins/tntsearch');


### PR DESCRIPTION
Arguments need to be passed as an array since passing shell commands as a string to the Process component is deprecated since Symfony 4.2. Related Grav fix which is also needed for this patch to work properly: https://github.com/getgrav/grav/commit/1661dc9ef7cc3ca921135c5a1e256aac03c4984c

This also finally fixes issue #81.