### PR TITLE
Fix default stemmer description

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,12 @@ The configuration options are as follows:
 * `fuzzy` - matches if the words are 'close' but not necessarily exact matches
 * `phrases` - automatically handle phrases support
 * `stemmer` - can be one of these types:
-  * `default` - no stemmer
+  * `default` - Porter stemmer for English language
+  * `no` - no stemmer
   * `arabic` - Arabic language
   * `german` - German language
   * `italian` - Italian language
-  * `porter` - Porter language
+  * `porter` - Porter stemmer for English language
   * `russian` - Russian language
   * `ukrainian` - Ukrainian language
 * `display_route` - display the route in the search results

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -173,13 +173,14 @@ form:
       size: small
       classes: fancy
       label: Stemmer
-      help: An automated process which produces a base string in an attempt to represent related words
+      help: An automated process which produces a base string in an attempt to represent related words. If your content is not in the language listed, for best search results it is recommended to disable the stemmer.
       options:
-        default: Default
+        default: Default (English)
+        no: Disabled
         arabic: Arabic
+        porter: English
         german: German
         italian: Italian
-        porter: Porter
         russian: Russian
         ukrainian: Ukrainian
 


### PR DESCRIPTION
As per https://github.com/teamtnt/tntsearch/blob/7de30b861a5379f7f3eb26f186bc17401ad5c93f/src/TNTSearch.php#L374 by default TNSSearch library uses Porter stemmer. Fix this in the documentation and allow an option to disable it.

Also, make it clearer for the user what Porter stemmer actually is and when to use it.