### PR TITLE
Fix default stemmer (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ enable_admin_page_events: true
 search_type: auto
 fuzzy: false
 phrases: true
-stemmer: default
+stemmer: 'no'
 display_route: true
 display_hits: true
 display_time: true
@@ -105,7 +105,6 @@ The configuration options are as follows:
 * `fuzzy` - matches if the words are 'close' but not necessarily exact matches
 * `phrases` - automatically handle phrases support
 * `stemmer` - can be one of these types:
-  * `default` - Porter stemmer for English language
   * `no` - no stemmer
   * `arabic` - Arabic language
   * `german` - German language

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -174,8 +174,8 @@ form:
       classes: fancy
       label: Stemmer
       help: An automated process which produces a base string in an attempt to represent related words. If your content is not in the language listed, for best search results it is recommended to disable the stemmer.
+      default: no
       options:
-        default: Default (English)
         no: Disabled
         arabic: Arabic
         porter: English

--- a/classes/GravTNTSearch.php
+++ b/classes/GravTNTSearch.php
@@ -224,7 +224,13 @@ class GravTNTSearch
     {
         $this->tnt->setDatabaseHandle(new GravConnector);
         $indexer = $this->tnt->createIndex($this->index);
-        $indexer->setLanguage($this->options['stemmer']);
+
+        // Disable stemmer for users with older configuration.
+        if ($this->options['stemmer'] == 'default') {
+            $indexer->setLanguage('no');
+        } else {
+            $indexer->setLanguage($this->options['stemmer']);
+        }
 
         $indexer->run();
     }

--- a/classes/GravTNTSearch.php
+++ b/classes/GravTNTSearch.php
@@ -42,7 +42,7 @@ class GravTNTSearch
         $locator = Grav::instance()['locator'];
 
         $search_type = $config->get('plugins.tntsearch.search_type', 'auto');
-        $stemmer = $config->get('plugins.tntsearch.stemmer', 'default');
+        $stemmer = $config->get('plugins.tntsearch.stemmer', 'no');
         $limit = $config->get('plugins.tntsearch.limit', 20);
         $snippet = $config->get('plugins.tntsearch.snippet', 300);
         $data_path = $locator->findResource('user://data', true) . '/tntsearch';
@@ -224,11 +224,7 @@ class GravTNTSearch
     {
         $this->tnt->setDatabaseHandle(new GravConnector);
         $indexer = $this->tnt->createIndex($this->index);
-
-        // Set the stemmer language if set
-        if ($this->options['stemmer'] !== 'default') {
-            $indexer->setLanguage($this->options['stemmer']);
-        }
+        $indexer->setLanguage($this->options['stemmer']);
 
         $indexer->run();
     }


### PR DESCRIPTION
TNTSearch changed default stemmer again https://github.com/teamtnt/tntsearch/commit/b675c625782b20563e4b01bf7c2934b701b80489.

To make our plugin behaviour consistent I would like to propose to remove 'default' value, use 'NoStemmer' as default and always set stemmer in the code.

Not sure if there is a better way to not break compatibility with older configs, it could produce errors, but everyone who have used 'default' previously should be aware about the change upstream anyway. 