### PR TITLE
Add input form autofocus switch

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -104,6 +104,17 @@ form:
         0: Disabled
       validate:
         type: bool
+    
+    autofocus:
+      type: toggle
+      label: Autofocus
+      highlight: 1
+      default: 1
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
 
     search_title:
       type: spacer

--- a/templates/partials/tntsearch.html.twig
+++ b/templates/partials/tntsearch.html.twig
@@ -12,7 +12,7 @@
 <form role="form" class="tntsearch-form" action="{{ nojs_action }}" method="get">
     {% block tntsearch_input %}
     <div id="tntsearch-wrapper" class="form-group{{ dropdown ? ' tntsearch-dropdown' : '' }}">
-        <input type="text" name="q" class="form-control form-input tntsearch-field{{ in_page ? ' tntsearch-field-inpage' : '' }}" data-tntsearch="{{ options|json_encode|e('html_attr') }}" placeholder="{{ placeholder }}" value="{{ not dropdown ? query|e : '' }}" autofocus>
+        <input type="text" name="q" class="form-control form-input tntsearch-field{{ in_page ? ' tntsearch-field-inpage' : '' }}" data-tntsearch="{{ options|json_encode|e('html_attr') }}" placeholder="{{ placeholder }}" value="{{ not dropdown ? query|e : '' }}" {% if config.get('plugins.tntsearch.autofocus') %}autofocus{% endif %}>
         <span class="tntsearch-clear"{{ not query or dropdown ? ' style="display: none;"' : '' }}>&times;</span>
     </div>
     {% endblock %}


### PR DESCRIPTION
If you want to place the TNTSearch Input field anywhere on a page (for example in sidebar), the input field is automatically activated because an autofocus HTML5 tag (https://www.w3schools.com/tags/att_input_autofocus.asp) is set. 

This pull request is to add a switch to disable this behavior if needed.