### PR TITLE
Adding Multi Stemmer to multilang setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ tntsearch:
 
 With the new 3.0 version of TNTSearch, support has been added for multiple languages (Grav 1.6 required).  Internally, this means that rather that store the index as `user:://data/tntsearch/grav.index`, multiple indexes are created per language configured in Grav.  For example if you have set the supported languages to `['en', 'fr', 'de']`, then when you perform an index,  you will get three files: `en.index`, `fr.index`, and `de.index`.  When querying the appropriate **active language** determines which index is queried.  For example, performing the search on a page called `/fr/search` will result in the `fr.index` database to be used, and French results to be returned.
 
-You can set a disctinct Stemmer for each language
+Not from the admin front end, only in the yaml, You can set a disctinct Stemmer for each language :
 ```
 stemmer:
     de: german

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Other than standard Grav requirements, this plugin does have some extra requirem
 * **PHP pdo_sqlite** Driver
 * **PHP pdo_mysql** Driver (only required because library references some MySQL constants, MySQL db is not used)
 
-| PHP by default comes with **PDO** and the vast majority of linux-based systems already come with SQLite.  
+| PHP by default comes with **PDO** and the vast majority of linux-based systems already come with SQLite.
 
 ### Installation of SQLite on Mac systems
 
@@ -47,7 +47,7 @@ $ brew install sqlite
 
 ### Installation of SQLite on Windows systems
 
-Download the appropriate version of SQLite from the [SQLite Downloads Page](https://www.sqlite.org/download.html).  
+Download the appropriate version of SQLite from the [SQLite Downloads Page](https://www.sqlite.org/download.html).
 
 Extract the downloaded ZIP file and run the `sqlite3.exe` executable.
 
@@ -87,7 +87,7 @@ filter:
   items:
     - root@.descendants
 powered_by: true
-search_object_type: Grav      
+search_object_type: Grav
 ```
 
 The configuration options are as follows:
@@ -110,12 +110,16 @@ The configuration options are as follows:
   * `no` - no stemmer
   * `arabic` - Arabic language
   * `croatian` - Croatian language
+  * `french` - French language
   * `german` - German language
   * `italian` - Italian language
+  * `polish` - Polish language
   * `porter` - Porter stemmer for English language
   * `portuguese` - Portuguese language
   * `russian` - Russian language
   * `ukrainian` - Ukrainian language
+  * an array of language: Stemmer (see Multi-Language Support)
+
 * `display_route` - display the route in the search results
 * `display_hits` - display the number of hits in the search results
 * `display_time` - display the execution time in the search results
@@ -135,7 +139,7 @@ TNTSearch relies on your content being indexed into the SQLite index database be
 
 ### Indexing
 
-The first step after installation of the plugin, is to index your content.  There are several ways you can accomplish this.  
+The first step after installation of the plugin, is to index your content.  There are several ways you can accomplish this.
 
 #### CLI Indexing
 
@@ -167,7 +171,7 @@ This indicates a successful indexing of your content.
 
 #### Admin Plugin Indexing
 
-If you are using the admin plugin you can index your content directly from the plugin.  TNTSearch adds a new **quick-tray** icon that lets you create a new index or re-index all your content quickly and conveniently with a single click.  
+If you are using the admin plugin you can index your content directly from the plugin.  TNTSearch adds a new **quick-tray** icon that lets you create a new index or re-index all your content quickly and conveniently with a single click.
 
 ![](assets/tntsearch-quicktray.png)
 
@@ -188,11 +192,22 @@ tntsearch:
 
 #### Multi-Language Support
 
-With the new 3.0 version of TNTSearch, support has been added for multiple languages (Grav 1.6 required).  Internally, this means that rather that store the index as `user:://data/tntsearch/grav.index`, multiple indexes are created per language configured in Grav.  For example if you have set the supported languages to `['en', 'fr', 'de']`, then when you perform an index,  you will get three files: `en.index`, `fr.index`, and `de.index`.  When querying the appropriate **active language** determines which index is queried.  For example, performing the search on a page called `/fr/search` will result in the `fr.index` database to be used, and French results to be returned.  
+With the new 3.0 version of TNTSearch, support has been added for multiple languages (Grav 1.6 required).  Internally, this means that rather that store the index as `user:://data/tntsearch/grav.index`, multiple indexes are created per language configured in Grav.  For example if you have set the supported languages to `['en', 'fr', 'de']`, then when you perform an index,  you will get three files: `en.index`, `fr.index`, and `de.index`.  When querying the appropriate **active language** determines which index is queried.  For example, performing the search on a page called `/fr/search` will result in the `fr.index` database to be used, and French results to be returned.
+
+You can set a disctinct Stemmer for each language
+```
+stemmer:
+    de: german
+    fr: french
+    en: porter
+    dk: no
+```
 
 Note Indexing will take longer depending on the number of languages you support as TNTSearch has to index each page in each language.
 
 > NOTE: While accented characters is supported in this release, there is currently no support in the underlying TNTSearch library to match non-accented characters to accented ones, so exact matches are required.
+
+
 
 #### Scheduler Support
 
@@ -245,9 +260,9 @@ For example, say we have a homepage that is built from a few modular sub-pages w
 {% endfor %}
 
 {{ page.content|raw }}
-``` 
+```
 
-As you can see this simply ensures the module pages as defined in the page's collection are displayed, then the actual page content is displayed.  
+As you can see this simply ensures the module pages as defined in the page's collection are displayed, then the actual page content is displayed.
 
 To instruct TNTSearch to index with this template rather than just using the Page content by itself, you just need to add an entry in the `home.md` frontmatter:
 
@@ -341,7 +356,7 @@ public function onTNTSearchQuery(Event $e)
         $query = $e['query'];
         $options = $e['options'];
         $fields = $e['fields'];
-        
+
         $fields->results[] = $page->route();
         $e->stopPropagation();
     }

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -174,7 +174,7 @@ form:
         0: Disabled
       validate:
         type: bool
-        
+
     stemmer:
       type: select
       size: small
@@ -186,6 +186,7 @@ form:
         no: Disabled
         arabic: Arabic
         croatian: Croatian
+        french: French
         porter: English
         german: German
         italian: Italian

--- a/classes/GravTNTSearch.php
+++ b/classes/GravTNTSearch.php
@@ -230,13 +230,25 @@ class GravTNTSearch
         $this->tnt->setDatabaseHandle(new GravConnector);
         $indexer = $this->tnt->createIndex($this->index);
 
-        // Disable stemmer for users with older configuration.
-        if ($this->options['stemmer'] == 'default') {
-            $indexer->setLanguage('no');
-        } else {
-            $indexer->setLanguage($this->options['stemmer']);
+		// Disable stemmer for users with older configuration.
+		$tmpStemmer = 'no';
+		if(is_array($this->options['stemmer']))
+        {
+			// New config allowing a Stemmer per lang for multilang site
+			$tmpStemmer = $this->options['stemmer'][$this->language];
+            if($tmpStemmer == 'default'){
+				// Allow user to use old config style just in case
+				$tmpStemmer = 'no';
+            }
         }
-
+        else if ($this->options['stemmer'] !== 'default') {
+            $tmpStemmer = $this->options['stemmer'];
+        }
+		$stemmer = $tmpStemmer;
+		$indexer->setLanguage($stemmer);
+		// Print stemmer on the cli
+		echo "\nStemmer : $stemmer";
+		echo "\n\n";
         $indexer->run();
     }
 


### PR DESCRIPTION
This change adds parsing of array of lang/stemmer value from the Yaml.
Unfortunately I couldn't figure out how to set up the ble print so that both Array or simple scalar could work. But the Doc explains how to do it (from the yaml).
Also added the French stemmer option in the docs