### PR TITLE
Initialise Twig before reindexing page content (fixes Admin2/API save 500)

### DIFF
--- a/classes/GravTNTSearch.php
+++ b/classes/GravTNTSearch.php
@@ -203,6 +203,17 @@ class GravTNTSearch
 
         /** @var Twig $twig */
         $twig = $grav['twig'];
+
+        // Ensure the Twig environment is initialised before processing the page
+        // content below. When indexing runs outside the normal page-render
+        // lifecycle — e.g. saving a page through the Grav 2.0 API / Admin2, which
+        // never runs the Twig processor — `$twig->twig` is null and both
+        // `$twig->processTemplate()` and `$page->content()` fail with
+        // "__clone method called on non-object" in Twig::processPage().
+        // Twig::init() is idempotent (guards on `null === $this->twig`), so this
+        // is a no-op during a normal render.
+        $twig->init();
+
         $header = $page->header();
 
         // @phpstan-ignore-next-line


### PR DESCRIPTION
### Problem

Saving a page through the Grav 2.0 **API / Admin2** returns **500** with `__clone method called on non-object` (`Twig.php:394`).

`onObjectSave` reindexes the saved page via `getCleanContent()` → `$page->content()`, which processes the page's Twig. `Twig::processPage()` does `clone $this->twig`, but the **API save request never runs the Twig processor**, so the `Twig\Environment` (`$this->twig`) is `null` and the clone throws. (Works in classic Admin, which initialised Twig during a save.)

Full report + stack trace: #145.

### Fix

Initialise Twig in `getCleanContent()` before processing page content. `Twig::init()` is idempotent — it guards on `null === $this->twig` — so this is a **no-op during normal page renders** and only builds the environment when indexing runs outside the render lifecycle (API/Admin2 save, CLI indexing, etc.). One line, plus an explanatory comment.

Fixes #145
